### PR TITLE
Problem: go lint shows some warnings

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -12,6 +12,7 @@ import (
 )
 
 var corsOrigins []string = nil
+// IPRateLimit, e.g. "100-M" for 100 requests/minute
 var IPRateLimit = ""
 var maxURLsInRequest uint = 0
 var disableRequestLogging = false

--- a/infrastructure/domain_rate_limited_checker.go
+++ b/infrastructure/domain_rate_limited_checker.go
@@ -35,6 +35,7 @@ func NewDomainRateLimitedChecker(ratePerSecond rate.Limit) *DomainRateLimitedChe
 	}
 }
 
+// CheckURL checks the desired URL applying rate limits per domain
 func (c *DomainRateLimitedChecker) CheckURL(ctx context.Context, url string) *URLCheckResult {
 	// if there's no limiting, just check
 	if c.ratePerSecond == 0 {

--- a/infrastructure/url_checker.go
+++ b/infrastructure/url_checker.go
@@ -37,6 +37,7 @@ type URLCheckResult struct {
 	BodyPatternsFound     []string
 }
 
+// BodyPatternConfig is unmarshalled from the configuration file
 type BodyPatternConfig struct {
 	Name  string
 	Regex string
@@ -98,7 +99,6 @@ func getURLCheckerSettings() urlCheckerSettings {
 		_, err := netUrl.Parse(proxyURL)
 		if err != nil {
 			log.Printf("Rejected proxyURL: %v", proxyURL)
-			proxyURL = ""
 		} else {
 			log.Printf("URLCheckerClient is using a proxy: %v", proxyURL)
 			s.ProxyURL = proxyURL

--- a/server/server.go
+++ b/server/server.go
@@ -29,7 +29,7 @@ import (
 const totalRequestDeadlineTimeoutSeconds = 15
 const largeRequestLoggingThreshold = 200
 
-// ServerOptions configures the web service instance
+// Options configures the web service instance
 type Options struct {
 	CORSOrigins           []string
 	IPRateLimit           string


### PR DESCRIPTION
via https://goreportcard.com/report/github.com/siemens/link-checker-service

## Solution

fixed the warnings, apart from the copyright notices that come before the package name