### PR TITLE
Resolve DNS when tracing

### DIFF
--- a/.link-checker-service.toml
+++ b/.link-checker-service.toml
@@ -67,3 +67,5 @@ userAgent = "lcs/0.9"
 browserUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
 acceptHeader = "*/*"
 skipCertificateCheck = false
+# this will fill out the URL response's remote_addr field when available
+enableRequestTracing = false

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 Notable changes will be documented here
 
+## 0.9.13
+
+- link-checker-service:
+  - optional: resolve remote addresses
+- sample UI:
+  - disable the CSV download button on no check status
+  - configurable service URL in the sample UI
+
 ## 0.9.12
 
 - new release packaging

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,7 @@ const (
 	browserUserAgentKey     = "browserUserAgent"
 	acceptHeaderKey         = "acceptHeader"
 	skipCertificateCheckKey = "skipCertificateCheck"
+	enableRequestTracingKey = "enableRequestTracing"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -91,7 +92,8 @@ func init() {
 	_ = viper.BindPFlag(httpClientMapKey+acceptHeaderKey, rootCmd.PersistentFlags().Lookup(acceptHeaderKey))
 	rootCmd.PersistentFlags().Bool(skipCertificateCheckKey, false, "HTTP client: skip verifying server certificates")
 	_ = viper.BindPFlag(httpClientMapKey+skipCertificateCheckKey, rootCmd.PersistentFlags().Lookup(skipCertificateCheckKey))
-
+	rootCmd.PersistentFlags().Bool(enableRequestTracingKey, false, "HTTP client: enable request tracing")
+	_ = viper.BindPFlag(httpClientMapKey+enableRequestTracingKey, rootCmd.PersistentFlags().Lookup(enableRequestTracingKey))
 	// service
 	rootCmd.PersistentFlags().UintP(maxConcurrentHTTPRequestsKey, "c", 256, "maximum number of total concurrent HTTP requests")
 	_ = viper.BindPFlag(maxConcurrentHTTPRequestsKey, rootCmd.PersistentFlags().Lookup(maxConcurrentHTTPRequestsKey))

--- a/infrastructure/url_checker_test.go
+++ b/infrastructure/url_checker_test.go
@@ -41,11 +41,26 @@ func TestSearchingForBodyPatterns(t *testing.T) {
 	assert.Equal(t, "google", res.BodyPatternsFound[0], "should have found at least one mention of google")
 }
 
+func TestTracingRequests(t *testing.T) {
+	setUpViperTestConfiguration()
+	res := NewURLCheckerClient().CheckURL(context.Background(), "https://google.com")
+	assert.Nil(t, res.Error)
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.Equal(t, res.RemoteAddr, "")
+
+	viper.Set("HTTPClient.enableRequestTracing", true)
+	res = NewURLCheckerClient().CheckURL(context.Background(), "https://google.com")
+	assert.Nil(t, res.Error)
+	assert.Equal(t, http.StatusOK, res.Code)
+	assert.NotEqual(t, res.RemoteAddr, "")
+}
+
 func setUpViperTestConfiguration() {
 	viper.SetEnvPrefix("LCS")
 	viper.Set("proxy", os.Getenv("LCS_PROXY"))
 	viper.Set("HTTPClient.timeoutSeconds", uint(15))
 	viper.Set("HTTPClient.maxRedirectsCount", uint(15))
+	viper.Set("HTTPClient.enableRequestTracing", false)
 	viper.Set("searchForBodyPatterns", false)
 	patterns := []struct {
 		Name  string

--- a/server/serialization.go
+++ b/server/serialization.go
@@ -30,6 +30,8 @@ type URLStatusResponse struct {
 	FetchedAtEpochSeconds int64 `json:"timestamp"`
 	// BodyPatternsFound will be filled with the configured regex patterns found in the response body
 	BodyPatternsFound []string `json:"body_patterns_found"`
+	// RemoteAddr is filled with the resolved address when `enableRequestTracing` is configured
+	RemoteAddr string `json:"remote_addr,omitempty"`
 }
 
 // CheckURLsResponse is a JSON structure for the bulk URL check response

--- a/server/server.go
+++ b/server/server.go
@@ -290,6 +290,7 @@ func (s *Server) checkURL(ctx context.Context, url URLRequest) URLStatusResponse
 		Error:                 errorString,
 		FetchedAtEpochSeconds: checkResult.FetchedAtEpochSeconds,
 		BodyPatternsFound:     checkResult.BodyPatternsFound,
+		RemoteAddr:            checkResult.RemoteAddr,
 	}
 	return urlStatus
 }


### PR DESCRIPTION
## Problem

It is not possible to distinguish intranet and internet links via URLs alone

## Solution

Resolving the remote address allows grouping URL check results to analyze their origins
