### PR TITLE
Simple authentication via JWT validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ debug.log
 link-checker-service
 test/jquery_example/jquery_example
 test/large_list_check/large_list_check
+*.pem

--- a/.link-checker-service.toml
+++ b/.link-checker-service.toml
@@ -39,6 +39,12 @@ disableRequestLogging = false
 #    "some-dom?in.*"
 # ]
 
+# Middleware used: https://github.com/appleboy/gin-jwt
+useJWTValidation = false
+privKeyFile = "./dummy.priv.cer"
+pubKeyFile = "./public.cer"
+signingAlgorithm = "RS384"
+
 # searchForBodyPatterns allows searching for patterns in response bodies
 # enabling searchForBodyPatterns will impact checker performance
 # this feature is only configurable via the config file

--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ For complex keys, such as `HTTPClient.userAgent`, take the uppercase key and rep
 LCS_HTTPCLIENT_USERAGENT="lcs/2.0"
 ```
 
+### Authentication
+
+The server implements a simple optional authentication via JWT token validation using a public certificate (middleware: [github.com/appleboy/gin-jwt](https://github.com/appleboy/gin-jwt)).
+
+[Currently](https://github.com/appleboy/gin-jwt/issues/236), the JWT middleware requires a dummy private
+certificate to be configured, even though it is not used for validation.
+
+See the [configuration file](.link-checker-service.toml) and the `serve` command help for detailed settings.
+
 ### Advanced Configuration
 
 Link checker can optionally detect patterns within successful HTTP response bodies, e.g. in pages with authentication.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -23,9 +23,9 @@ var jwtValidationOptions *s.JWTValidationOptions = nil
 
 const bindAddressKey = "bindAddress"
 const useJWTValidationKey = "useJWTValidation"
-const PrivKeyFileKey = "privKeyFile"
-const PubKeyFileKey = "pubKeyFile"
-const SigningAlgorithmKey = "signingAlgorithm"
+const privKeyFileKey = "privKeyFile"
+const pubKeyFileKey = "pubKeyFile"
+const signingAlgorithmKey = "signingAlgorithm"
 
 var serveCmd = &cobra.Command{
 	Use:   "serve",
@@ -73,9 +73,9 @@ func fetchConfig() {
 
 func fetchJWTValidationConfig() {
 	jwtValidationOptions = &s.JWTValidationOptions{
-		PrivKeyFile:      viper.GetString(PrivKeyFileKey),
-		PubKeyFile:       viper.GetString(PubKeyFileKey),
-		SigningAlgorithm: viper.GetString(SigningAlgorithmKey),
+		PrivKeyFile:      viper.GetString(privKeyFileKey),
+		PubKeyFile:       viper.GetString(pubKeyFileKey),
+		SigningAlgorithm: viper.GetString(signingAlgorithmKey),
 	}
 }
 
@@ -91,17 +91,17 @@ func init() {
 	flags.BoolVar(&useJWTValidation, useJWTValidationKey, false,
 		"use JWT validation")
 
-	flags.String(PrivKeyFileKey, "dummy.priv.cer",
+	flags.String(privKeyFileKey, "dummy.priv.cer",
 		"Provide a valid dummy private key certificate (work-around)")
-	_ = viper.BindPFlag(PrivKeyFileKey, flags.Lookup(PrivKeyFileKey))
+	_ = viper.BindPFlag(privKeyFileKey, flags.Lookup(privKeyFileKey))
 
-	flags.String(PubKeyFileKey, "public.cer",
+	flags.String(pubKeyFileKey, "public.cer",
 		"Provide a valid public key to validate the JWT tokens against")
-	_ = viper.BindPFlag(PubKeyFileKey, flags.Lookup(PubKeyFileKey))
+	_ = viper.BindPFlag(pubKeyFileKey, flags.Lookup(pubKeyFileKey))
 
-	flags.String(SigningAlgorithmKey, "RS384",
+	flags.String(signingAlgorithmKey, "RS384",
 		"Provide a valid public key to validate the JWT tokens against")
-	_ = viper.BindPFlag(SigningAlgorithmKey, flags.Lookup(SigningAlgorithmKey))
+	_ = viper.BindPFlag(signingAlgorithmKey, flags.Lookup(signingAlgorithmKey))
 
 	flags.StringVar(&IPRateLimit, "IPRateLimit", "", "rate-limit requests from an IP. e.g. 5-S (5 per second), 1000-H (1000 per hour)")
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/siemens/link-checker-service
 go 1.15
 
 require (
+	github.com/appleboy/gin-jwt/v2 v2.6.4
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a/go.mod h1:LButx
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/appleboy/gin-jwt/v2 v2.6.4 h1:4YlMh3AjCFnuIRiL27b7TXns7nLx8tU/TiSgh40RRUI=
+github.com/appleboy/gin-jwt/v2 v2.6.4/go.mod h1:CZpq1cRw+kqi0+yD2CwVw7VGXrrx4AqBdeZnwxVmoAs=
+github.com/appleboy/gofight/v2 v2.1.2 h1:VOy3jow4vIK8BRQJoC/I9muxyYlJ2yb9ht2hZoS3rf4=
+github.com/appleboy/gofight/v2 v2.1.2/go.mod h1:frW+U1QZEdDgixycTj4CygQ48yLTUhplt43+Wczp3rw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -41,6 +45,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -286,6 +291,12 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=

--- a/main_test.go
+++ b/main_test.go
@@ -478,6 +478,6 @@ func TestJWTAuthentication(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, w.Code, "A bad JWT token should not have been valid")
 
 	// cleanup
-	os.Remove(privKey)
-	os.Remove(pubKey)
+	_ = os.Remove(privKey)
+	_ = os.Remove(pubKey)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -347,9 +347,9 @@ func (s *Server) setUpJWTValidation() {
 
 	// the jwt middleware
 	middleware, err := jwt.New(&jwt.GinJWTMiddleware{
-		PrivKeyFile:      s.options.JWTValidationOptions.PrivKeyFile,      //"./dummy.private.cer",
-		PubKeyFile:       s.options.JWTValidationOptions.PubKeyFile,       //"./2020-02-13.myid-qa.siemens.com-Signing_Certificate.cer",
-		SigningAlgorithm: s.options.JWTValidationOptions.SigningAlgorithm, // "RS384",
+		PrivKeyFile:      s.options.JWTValidationOptions.PrivKeyFile,
+		PubKeyFile:       s.options.JWTValidationOptions.PubKeyFile,
+		SigningAlgorithm: s.options.JWTValidationOptions.SigningAlgorithm,
 	})
 
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ const totalRequestDeadlineTimeoutSecondsPerURL = 15
 const totalRequestDeadlineTimeoutSeconds = 300
 const largeRequestLoggingThreshold = 200
 
+// JWTValidationOptions configures authentication via JWT validation
 type JWTValidationOptions struct {
 	PrivKeyFile      string
 	PubKeyFile       string


### PR DESCRIPTION
## Problem

the service runs unauthenticated

## Solution

while an authenticating proxy can be used in front of the service, a simple form of [JWT](https://jwt.io/) token validation can be used with OAuth2 providers

Test using [HTTPie](https://httpie.org/docs):

### run the service

```shell
link-checker-service serve --useJWTValidation \
  --privKeyFile dummy.key.pem \
  --pubKeyFile cert.pem
```

### fetch a token

```shell
http --form POST https://{endpoint}/token grant_type=client_credentials client_id={client_id} client_secret={client_secret}
```

&darr;

```json
{
    "access_token": "{token}",
    "expires_in": 1234,
    "token_type": "Bearer"
}
```

### make an authenticated call

```shell
http -F http://localhost:8080/version "Authorization:Bearer {token}"
HTTP/1.1 200 OK

(devel)
```