### PR TITLE
PAC script proxy configuration plugin

### DIFF
--- a/.link-checker-service.toml
+++ b/.link-checker-service.toml
@@ -2,6 +2,8 @@
 # This file is not subject to the MPLv2 license, and can be edited freely.
 
 # proxy = "http://<some-proxy>:<port>"
+# pacScriptURL = "http://<some-proxy>/<some-proxy.pac>"
+
 
 # uncomment to bind to a custom address
 # bindAddress = "127.0.0.1:8080"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 Notable changes will be documented here
 
+## 0.9.20
+
+- link-checker-service:
+  - a new URL checker plugin: `urlcheck-pac`, configured via `pacScriptURL`
+    for more complex proxy scenarios
+  - more reasons to retry a check with a different checker plugin added
+
 ## 0.9.19
 
 - link-checker-service:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Notable changes will be documented here
   - a new URL checker plugin: `urlcheck-pac`, configured via `pacScriptURL`
     for more complex proxy scenarios
   - more reasons to retry a check with a different checker plugin added
+  - checker plugins are now traced in the `check_trace` field of the `URLStatusResponse`
 
 ## 0.9.19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Notable changes will be documented here
     - logging the configuration before validating it
   - configurable sequence or URL checker plugins, e.g. with and without using a proxy
   - logging `GOMAXPROCS` on `serve`
-  - simplest health & liveness check + version endpoints are now unauthenticated and not rate-limited
+  - the simplest health & liveness check + version endpoints are now unauthenticated and not rate-limited
 
 
 ## 0.9.18

--- a/README.md
+++ b/README.md
@@ -176,6 +176,27 @@ certificate to be configured, even though it is not used for validation.
 
 See the [configuration file](.link-checker-service.toml) and the `serve` command help for detailed settings.
 
+### URL Checker Plugins
+
+URLs may be checked using different methods, e.g. with an HTTP client with or without using a proxy.
+Depending on the connectivity available to the link checker service, the sequence of checks can be influenced
+via a configuration of the URL Checker Plugins.
+
+E.g.:
+
+```toml
+urlCheckerPlugins = [
+    "urlcheck-noproxy",
+    "urlcheck",
+    "urlcheck-pac",
+]
+```
+
+By default, the `urlcheck` plugin is used, which uses an HTTP client with a proxy, if one is configured,
+and without one, if not. `urlcheck-noproxy` uses a client explicitly without a proxy set. 
+`urlcheck-pac` generates a client for each URL depending on the proxy configuration returned via the
+PAC script, configured via the `pacScriptURL` option. Only the first proxy returned by the PAC script will be used. 
+
 ### Advanced Configuration
 
 Link checker can optionally detect patterns within successful HTTP response bodies, e.g. in pages with authentication.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ const (
 	// HTTP client
 	httpClientMapKey        = "HTTPClient."
 	proxyKey                = "proxy"
+	pacScriptURLKey         = "pacScriptURL"
 	maxRedirectsCountKey    = "maxRedirectsCount"
 	timeoutSecondsKey       = "timeoutSeconds"
 	userAgentKey            = "userAgent"
@@ -80,6 +81,8 @@ func init() {
 	// HTTP client
 	rootCmd.PersistentFlags().StringP(proxyKey, "", "", "HTTP client: proxy server to use, e.g. http://myproxy:8080")
 	_ = viper.BindPFlag(proxyKey, rootCmd.PersistentFlags().Lookup(proxyKey))
+	rootCmd.PersistentFlags().StringP(pacScriptURLKey, "", "", "HTTP client: PAC script URL, e.g. http://myproxy/proxy.pac")
+	_ = viper.BindPFlag(pacScriptURLKey, rootCmd.PersistentFlags().Lookup(pacScriptURLKey))
 
 	rootCmd.PersistentFlags().Uint(maxRedirectsCountKey, 15, "HTTP client: maximum number of redirects to follow")
 	_ = viper.BindPFlag(httpClientMapKey+maxRedirectsCountKey, rootCmd.PersistentFlags().Lookup(maxRedirectsCountKey))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/appleboy/gin-jwt/v2 v2.6.4
+	github.com/darren/gpac v0.0.0-20200702020854-d9398608e64a
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/gin-contrib/cors v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -42,12 +42,18 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/darren/gpac v0.0.0-20200702020854-d9398608e64a h1:S+G7wPFtDOjm5jVeBkbTVSriE1yoSO/ZTrUBN/Qqa/o=
+github.com/darren/gpac v0.0.0-20200702020854-d9398608e64a/go.mod h1:1Id6bMaG5dQYTt+Pk0msQw4r/+kkuzfuFwoictr5mcU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dlclark/regexp2 v1.2.0 h1:8sAhBGEM0dRWogWqWyQeIJnxjWO6oIjl8FKqREDsGfk=
+github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
+github.com/dop251/goja v0.0.0-20200629185240-bfd59704b500 h1:QthjkRYZQj+FcH5GZXltnlBiyW19WLb+l7R0TrZChNw=
+github.com/dop251/goja v0.0.0-20200629185240-bfd59704b500/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -85,6 +91,8 @@ github.com/go-playground/validator/v10 v10.4.0/go.mod h1:nlOn6nFhuKACm19sB/8EGNn
 github.com/go-redis/redis/v7 v7.2.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-resty/resty/v2 v2.3.0 h1:JOOeAvjSlapTT92p8xiS19Zxev1neGikoHsXJeOq8So=
 github.com/go-resty/resty/v2 v2.3.0/go.mod h1:UpN9CgLZNsv4e9XG50UU8xdI0F43UQ4HmxLBDwaroHU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=

--- a/infrastructure/url_checker.go
+++ b/infrastructure/url_checker.go
@@ -312,8 +312,20 @@ func (l *localURLChecker) CheckURL(ctx context.Context, urlToCheck string, lastR
 	return lastResult, false
 }
 
-func (l *localURLChecker) autoSelectClientFor(check string) *resty.Client {
+func (l *localURLChecker) autoSelectClientFor(urlToCheck string) *resty.Client {
 	tmpSettings := l.c.settings
+	proxies, err := l.c.autoProxy.FindProxy(urlToCheck)
+	if err == nil && len(proxies) > 0 {
+		// choosing the first available proxy
+		for _, proxy := range proxies {
+			if proxy.Type == "PROXY" {
+				tmpSettings.ProxyURL = proxies[0].URL()
+				break
+			}
+		}
+	} else {
+		log.Printf("Could not find a proxy for %v", urlToCheck)
+	}
 	return buildClient(tmpSettings)
 }
 

--- a/infrastructure/url_checker.go
+++ b/infrastructure/url_checker.go
@@ -436,11 +436,18 @@ func (c *URLCheckerClient) tryGetRequestAndProcessResponseBody(ctx context.Conte
 }
 
 func shouldRetryBasedOnStatus(code int) bool {
+	if code < 300 {
+		return false
+	}
+
 	return code == http.StatusForbidden ||
 		code == http.StatusMethodNotAllowed ||
 		code == http.StatusServiceUnavailable ||
 		code == http.StatusNotFound ||
-		code == CustomHTTPErrorCode
+		code == CustomHTTPErrorCode ||
+		code == http.StatusGatewayTimeout ||
+		code == http.StatusBadGateway ||
+		code == http.StatusRequestTimeout
 }
 
 func (c *URLCheckerClient) tryHeadRequestDefault(ctx context.Context, urlToCheck string, client *resty.Client) *URLCheckResult {

--- a/infrastructure/url_checker_plugin.go
+++ b/infrastructure/url_checker_plugin.go
@@ -4,6 +4,9 @@ import "context"
 
 // URLCheckerPlugin represents one low-level URL checker in a chain of checkers
 type URLCheckerPlugin interface {
+	// Name returns the name of the plugin to use in logging and result reporting
+	Name() string
+
 	// CheckURL gets the urlToCheck and lastResult, which it can process, and return the next result
 	// and a boolean flag, whether the chain should be interrupted, and the last result - simply returned
 	// ctx can be used to cancel the request prematurely

--- a/infrastructure/url_checker_test.go
+++ b/infrastructure/url_checker_test.go
@@ -112,8 +112,13 @@ func TestCheckerSequenceMatters(t *testing.T) {
 	viper.Set("urlCheckerPlugins", []string{"_always_ok", "_always_bad"})
 	res := NewURLCheckerClient().CheckURL(context.Background(), "http://lkasdjfasf.com/123987")
 	assert.Equal(t, Ok, res.Status, "the result should've been Ok as _always_ok comes first and aborts the chain")
+	assert.Equal(t, []URLCheckerPluginTrace{
+		{Name: "_always_ok", Code: 200},
+	}, res.CheckerTrace)
 
 	viper.Set("urlCheckerPlugins", []string{"_always_bad", "_always_ok"})
 	res = NewURLCheckerClient().CheckURL(context.Background(), "http://lkasdjfasf.com/123987")
 	assert.NotEqual(t, Ok, res.Status, "the result should not have been Ok as _always_bad comes first and aborts the chain")
+	assert.Len(t, res.CheckerTrace, 1)
+	assert.Equal(t, "_always_bad", res.CheckerTrace[0].Name)
 }

--- a/server/serialization.go
+++ b/server/serialization.go
@@ -16,6 +16,12 @@ type CheckURLsRequest struct {
 	Urls []URLRequest `json:"urls"`
 }
 
+// URLCheckTraceResponse reflects a trace of a single url checker plugin run
+type URLCheckTraceResponse struct {
+	Name string
+	Code int
+}
+
 // URLStatusResponse is the JSON response structure for one URL
 type URLStatusResponse struct {
 	// URLRequest is echoed back for correlation purposes
@@ -32,6 +38,8 @@ type URLStatusResponse struct {
 	BodyPatternsFound []string `json:"body_patterns_found"`
 	// RemoteAddr is filled with the resolved address when `enableRequestTracing` is configured
 	RemoteAddr string `json:"remote_addr,omitempty"`
+	// CheckTrace is a trace of the url checker plugin responses
+	CheckTrace []URLCheckTraceResponse `json:"check_trace"`
 }
 
 // CheckURLsResponse is a JSON structure for the bulk URL check response

--- a/server/server.go
+++ b/server/server.go
@@ -321,8 +321,20 @@ func (s *Server) checkURL(ctx context.Context, url URLRequest) URLStatusResponse
 		FetchedAtEpochSeconds: checkResult.FetchedAtEpochSeconds,
 		BodyPatternsFound:     checkResult.BodyPatternsFound,
 		RemoteAddr:            checkResult.RemoteAddr,
+		CheckTrace:            translateCheckerTrace(checkResult.CheckerTrace),
 	}
 	return urlStatus
+}
+
+func translateCheckerTrace(trace []infrastructure.URLCheckerPluginTrace) []URLCheckTraceResponse {
+	var res []URLCheckTraceResponse
+	for _, traceRes := range trace {
+		res = append(res, URLCheckTraceResponse{
+			Name: traceRes.Name,
+			Code: traceRes.Code,
+		})
+	}
+	return res
 }
 
 func urlBlacklisted(url URLRequest) URLStatusResponse {


### PR DESCRIPTION
## Problem

Sometimes, configuring one proxy is not enough

## Solution

In this case, a [Proxy auto-config (PAC)](https://en.wikipedia.org/wiki/Proxy_auto-config) makes sense

### Configuration

```toml
urlCheckerPlugins = [
    "urlcheck-pac", # use this url checker plugin
]

# and a PAC url
pacScriptURL = "http://myproxy/proxy.pac"
```

Using https://github.com/darren/gpac
